### PR TITLE
Fix ImageSource.toBase64String missing Format

### DIFF
--- a/Showcase_Apps/PrintAndQRCodeApp/PrintingSampleApp/Rules/GetQRCodeImage.js
+++ b/Showcase_Apps/PrintAndQRCodeApp/PrintingSampleApp/Rules/GetQRCodeImage.js
@@ -9,6 +9,6 @@ export default function GetQRCodeImage(context) {
 		if (!clientData.QRCodeImageSource) {
 				clientData.QRCodeImageSource = GenerateQRCode(context);
 		}
-		var base64Str = clientData.QRCodeImageSource.toBase64String();
+		var base64Str = clientData.QRCodeImageSource.toBase64String("png");
 		return "data:image/png;base64," + base64Str;
 }


### PR DESCRIPTION
Without the format, in iOS it will return null.